### PR TITLE
Exclude cockpit.conf from verification

### DIFF
--- a/ovirt-cockpit-sso.spec
+++ b/ovirt-cockpit-sso.spec
@@ -106,7 +106,7 @@ systemctl daemon-reload
 %{app_root_dir}/ovirt-cockpit-sso.xml
 %{_usr}/lib/systemd/system/ovirt-cockpit-sso.service
 
-%config %{app_root_dir}/config/cockpit/cockpit.conf
+%config %verify(not md5 size mtime) %{app_root_dir}/config/cockpit/cockpit.conf
 
 %changelog
 * Mon Aug 3 2018 Marek Libra <mlibra@redhat.com> - 0.1.0


### PR DESCRIPTION
In one of the preceding commits, cockpit.conf has been marked as a
config file.  However it is still reported as a changed file on
verification, although with the config file mark.  It confuses some
tools and since the file is supposed to be modified automatically, the
warning is useless anyway.  So let's exclude the file from
verification completely.

See https://bugzilla.redhat.com/1567936.