### PR TITLE
Mark temp repo directory as safe for COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -3,6 +3,11 @@
 installdeps:
 	dnf -y install make
 
-srpm: installdeps
+# explicity mark the copr generated git repo directory (which is done prior to the mock
+# call to the make_srpm and will be the current pwd) as safe for git commands
+git-safe:
+	git config --global --add safe.directory "$(shell pwd)"
+
+srpm: installdeps git-safe
 	make srpm
 	cp tmp.repos/SRPMS/*.src.rpm $(outdir)

--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,13 +1,13 @@
-.PHONY: installdeps srpm
+.PHONY: installdeps git_cfg_safe srpm
 
 installdeps:
 	dnf -y install make
 
-# explicity mark the copr generated git repo directory (which is done prior to the mock
-# call to the make_srpm and will be the current pwd) as safe for git commands
-git-safe:
+git_cfg_safe:
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work because of the fix for CVE-2022-24765
 	git config --global --add safe.directory "$(shell pwd)"
 
-srpm: installdeps git-safe
+srpm: installdeps git_cfg_safe
 	make srpm
 	cp tmp.repos/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
When building from COPR the project is cloned into temporary directory,
which is not owned by current user. From git 2.35.2 such directory needs
to be marked as safe inn order git commands work correctly.